### PR TITLE
Test child processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,19 @@ What happens over sockets, you ask? Let's name a few:
 
 ![Build Status](https://github.com/kellym/hellodog/actions/workflows/test.yml/badge.svg)
 
+## Quick Start
+
 #### Patching Socket
 When using HelloDog, net.Socket needs to be patched before anything else
 extends or creates a Socket in order for that to be recorded. Patching can be
-done by either calling `patch()` or by assigning `record`:
+done by either calling `patch()` or by assigning `track`:
 
 ```javascript
-require('hellodog').patch();
-
 // automatically patches when retrieving the track method:
 const { track } = require('hellodog');
+
+// or more explicitly:
+require('hellodog').patch();
 
 // net Socket can also be unpatched:
 require('hellodog').unpatch();
@@ -53,6 +56,8 @@ track((resolve, reject) => {
 }).then((log) => {
 
 });
+
+const log = await track(fnCall);
 ```
 
 Response from `console.log`:

--- a/test/track.js
+++ b/test/track.js
@@ -1,9 +1,10 @@
-const tap        = require('tap'),
-      { track }  = require('../index'),
-      express    = require('express'),
-      http       = require('http'),
-      https      = require('https'),
-      pem        = require('pem');
+const tap       = require('tap'),
+      { track } = require('../index'),
+      { spawn } = require('child_process'),
+      express   = require('express'),
+      http      = require('http'),
+      https     = require('https'),
+      pem       = require('pem');
 
 // we're using a self-signed cert for our tests.
 // important: must run tests with environment variable
@@ -79,6 +80,20 @@ tap.test('should track console.error', (t) => {
     t.equal(s.events.length, 1);
     t.ok(s.events[0].request);
     t.equal(s.source, 'stderr');
+    t.end();
+  });
+});
+
+tap.test('should track child processes', (t) => {
+  track((done) => {
+    const ls = spawn('echo',["Hello, world!"]);
+    ls.on('close', () => done());
+  }, (log) => {
+    const s = log[0];
+    t.ok(s.events);
+    t.equal(s.events.length, 1);
+    t.ok(s.events[0].response);
+    t.equal(s.source, 'pipe');
     t.end();
   });
 });


### PR DESCRIPTION
This ensures that `hellodog` works with recording data from a `spawn` command.