### PR TITLE
Log more events and fix connection handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Response from `console.log`:
 [
   {
     events: [
-      { request: 'Hello, dog!\n', created_at: 1489460314753.3242 },
-      { request: 'Goodbye, dog!\n', created_at: 1489460314753.4758 }
+      { type: 'write', data: 'Hello, dog!\n', created_at: 1489460314753.3242 },
+      { type: 'write', data: 'Goodbye, dog!\n', created_at: 1489460314753.4758 }
     ],
     source: 'stdout'
   }
@@ -103,11 +103,17 @@ Response from HTTP transaction:
   {
     events: [
       {
-        request: 'GET / HTTP/1.1\r\nHost: localhost:8888\r\nConnection: close\r\n\r\n',
+        type: 'connect',
+        created_at: 1489460545610.2593
+      },
+      {
+        type: 'write',
+        data: 'GET / HTTP/1.1\r\nHost: localhost:8888\r\nConnection: close\r\n\r\n',
         created_at: 1489460545620.1575
       },
       {
-        response: 'HTTP/1.1 200 OK\r\nX-Powered-By: Express\r\nContent-length: 13\r\nDate: Tue, 14 Mar 2017 03:02:25 GMT\r\nConnection: close\r\n\r\nHello, world!',
+        type: 'read',
+        data: 'HTTP/1.1 200 OK\r\nX-Powered-By: Express\r\nContent-length: 13\r\nDate: Tue, 14 Mar 2017 03:02:25 GMT\r\nConnection: close\r\n\r\nHello, world!',
         created_at: 1489460545628.0654
       }
     ],

--- a/lib/info.js
+++ b/lib/info.js
@@ -38,10 +38,10 @@ const info = module.exports = {
       isModified = options.port || options.host;
     }
     if (isModified) {
-      if (connectionInfo[socket]) {
-        connectionInfo[socket] = merge(connectionInfo[socket], options);
+      if (connectionInfo.has(socket)) {
+        connectionInfo.set(socket, merge(connectionInfo.get(socket), options));
       } else {
-        connectionInfo[socket] = options;
+        connectionInfo.set(socket, options);
       }
     } else {
       options = undefined;
@@ -50,7 +50,7 @@ const info = module.exports = {
   },
 
   getConnection (socket) {
-    return connectionInfo[socket];
+    return connectionInfo.get(socket);
   },
 
   // best guess to determine the socket type

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,42 @@
+const merge = require('./merge');
+const state = require('./state');
+const getLog = require('./getLog');
+
+const baseCreatedAt = (new Date()).getTime();
+const baseHrtime = process.hrtime();
+
+module.exports = {
+  getLog,
+
+  logEvent (socket, eventType, data, { connection, ...opts } = {}) {
+    const event = {
+      type: eventType,
+      created_at: preciseTime()
+    };
+    if (data) {
+      event.data = toString(data);
+    }
+    state.forEach(asyncState => {
+      const log = getLog(asyncState, socket);
+      log.events.push(event);
+      if (connection) {
+        merge(log.connection, connection);
+      }
+      merge(log, opts);
+    });
+  }
+};
+
+function preciseTime () {
+  const time = process.hrtime(baseHrtime);
+  return baseCreatedAt + (time[0] * 1000) + (time[1] / 1000000);
+}
+
+
+function toString (data) {
+  if (Buffer.isBuffer(data) || typeof data === 'string') {
+    return data.toString();
+  } else {
+    return JSON.stringify(data);
+  }
+}

--- a/lib/monitorSocket.js
+++ b/lib/monitorSocket.js
@@ -1,4 +1,4 @@
-const getLog = require('./getLog');
+const { logEvent } = require('./log');
 const info = require('./info');
 const merge = require('./merge');
 const state = require('./state');
@@ -7,33 +7,22 @@ const state = require('./state');
 // details about this transaction.
 module.exports = function monitorSocket (socket) {
   socket.on('error', err => {
-    state.forEach(asyncState => {
-      const log = getLog(asyncState, socket);
-      merge(log.connection, {
-        err: err || undefined
-      });
-    });
+    logEvent(socket, 'error', null, { err });
   });
 
   // when the socket registers as secure, let's track that for our log
   socket.on('secure', () => {
-    state.forEach(asyncState => {
-      const log = getLog(asyncState, socket);
-      log.encrypted = true;
-    });
+    logEvent(socket, 'secure', null, { encrypted: true });
+  });
+
+  socket.on('secureConnect', () => {
+    logEvent(socket, 'secureConnect', null, { encrypted: true });
   });
 
   // the lookup event gives us our host name as well as an ip address,
   // and any DNS lookup error
-  socket.on('lookup', (err, address, family, host) => {
-    state.forEach(asyncState => {
-      const log = getLog(asyncState, socket);
-      merge(log.connection, {
-        err: err || undefined,
-        ip: address,
-        host: host
-      });
-    });
+  socket.on('lookup', (err, ip, family, host) => {
+    logEvent(socket, 'lookup', null, { connection: { err, ip, host } });
   });
 
   // ensure on connect that if this is the decrypted version of an
@@ -41,17 +30,14 @@ module.exports = function monitorSocket (socket) {
   // some which may come from the parent
   socket.on('connect', (err, req) => {
     const source = info.socketType(socket);
-    state.forEach(asyncState => {
-      const log = getLog(asyncState, socket);
-      const parentLog = socket._parent ? getLog(asyncState, socket._parent) : {};
-      // redefine the source property, since TLSSocket won't give us a
-      // proper type until now
-      log.source = source;
-      merge(log.connection, parentLog.connection, {
-        err: err,
-        port: socket.remotePort,
-        ip: socket.remoteAddress
-      });
-    });
+    const connection = {
+      err,
+      port: socket.remotePort,
+      ip: socket.remoteAddress
+    };
+    if (socket._parent) {
+      merge(connection, info.getConnection(socket._parent));
+    }
+    logEvent(socket, 'connect', null, { connection, source });
   });
 };

--- a/lib/patch.js
+++ b/lib/patch.js
@@ -15,6 +15,7 @@ module.exports = {
       wrapMethod(_prototype, 'connect', wrap.connect);
       wrapMethod(_prototype, '_writeGeneric', wrap.writeGeneric);
       wrapMethod(_prototype, 'push', wrap.push);
+      wrapMethod(_prototype, 'emit', wrap.emit);
     }
   },
 
@@ -25,6 +26,7 @@ module.exports = {
       net.Socket.prototype.connect = wrappedMethods.connect;
       net.Socket.prototype._writeGeneric = wrappedMethods._writeGeneric;
       net.Socket.prototype.push = wrappedMethods.push;
+      net.Socket.prototype.emit = wrappedMethods.emit;
       wrappedMethods = {};
     }
   }

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -1,11 +1,8 @@
 const monitorSocket = require('./monitorSocket');
 const state = require('./state');
 const info = require('./info');
-const getLog = require('./getLog');
-
+const { logEvent } = require('./log');
 const observedSockets = new WeakSet();
-const baseCreatedAt = (new Date()).getTime();
-const baseHrtime = process.hrtime();
 
 module.exports = {
 
@@ -29,7 +26,7 @@ module.exports = {
     // args: writev, data, encoding, callback
     const data = args[1];
     if (!socket.connecting && socket._handle && state.active) {
-      log(socket, 'request', data);
+      logEvent(socket, 'request', data);
     }
     return fn.apply(socket, args);
   },
@@ -38,7 +35,7 @@ module.exports = {
   push (socket, fn, args) {
     const data = args[0];
     if (data) {
-      log(socket, 'response', data);
+      logEvent(socket, 'response', data);
     }
     return fn.apply(socket, args);
   }
@@ -58,29 +55,5 @@ function startTrackingSocket (socket, opts = []) {
     //  start listening to events that
     // tell details about the socket
     monitorSocket(socket);
-  }
-}
-
-function preciseTime () {
-  const time = process.hrtime(baseHrtime);
-  return baseCreatedAt + (time[0] * 1000) + (time[1] / 1000000);
-}
-
-function log (socket, eventType, data) {
-  const event = {
-    [eventType]: toString(data),
-    created_at: preciseTime()
-  };
-  state.forEach(asyncState => {
-    const log = getLog(asyncState, socket);
-    log.events.push(event);
-  });
-}
-
-function toString (data) {
-  if (Buffer.isBuffer(data) || typeof data === 'string') {
-    return data.toString();
-  } else {
-    return JSON.stringify(data);
   }
 }

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -4,6 +4,17 @@ const info = require('./info');
 const { logEvent } = require('./log');
 const observedSockets = new WeakSet();
 
+const handledEvents = [
+  'data',
+  'secure',
+  'lookup',
+  'secureConnect',
+  'connect',
+  'error',
+  'newListener',
+  'removeListener'
+];
+
 module.exports = {
 
   // constructor wrapper for net.Socket
@@ -26,7 +37,7 @@ module.exports = {
     // args: writev, data, encoding, callback
     const data = args[1];
     if (!socket.connecting && socket._handle && state.active) {
-      logEvent(socket, 'request', data);
+      logEvent(socket, 'write', data);
     }
     return fn.apply(socket, args);
   },
@@ -35,7 +46,15 @@ module.exports = {
   push (socket, fn, args) {
     const data = args[0];
     if (data) {
-      logEvent(socket, 'response', data);
+      logEvent(socket, 'read', data);
+    }
+    return fn.apply(socket, args);
+  },
+
+  emit(socket, fn, args) {
+    const eventType = args[0];
+    if (!handledEvents.includes(eventType)) {
+      logEvent(socket, eventType);
     }
     return fn.apply(socket, args);
   }

--- a/test/ftp.spec.js
+++ b/test/ftp.spec.js
@@ -30,6 +30,6 @@ test('tracks ftp server', async done => {
     client.connect(options);
   });
   assert.equal(log.length, 2);
-  assert.equal(log[0].events.filter(e => e.request && e.request.indexOf(options.user) !== -1).length, 1);
-  assert.equal(log[0].events.filter(e => e.request && e.request.indexOf(options.password) !== -1).length, 1);
+  assert.equal(log[0].events.filter(e => e.type === 'request' && e.data.indexOf(options.user) !== -1).length, 1);
+  assert.equal(log[0].events.filter(e => e.type === 'request' && e.data.indexOf(options.password) !== -1).length, 1);
 });

--- a/test/ftp.spec.js
+++ b/test/ftp.spec.js
@@ -30,6 +30,6 @@ test('tracks ftp server', async done => {
     client.connect(options);
   });
   assert.equal(log.length, 2);
-  assert.equal(log[0].events.filter(e => e.type === 'request' && e.data.indexOf(options.user) !== -1).length, 1);
-  assert.equal(log[0].events.filter(e => e.type === 'request' && e.data.indexOf(options.password) !== -1).length, 1);
+  assert.equal(log[0].events.filter(e => e.type === 'write' && e.data.indexOf(options.user) !== -1).length, 1);
+  assert.equal(log[0].events.filter(e => e.type === 'write' && e.data.indexOf(options.password) !== -1).length, 1);
 });

--- a/test/track.spec.js
+++ b/test/track.spec.js
@@ -37,9 +37,10 @@ test('tracks http socket requests and responses', () => {
         const s = log[0];
         assert.equal(log.length, 1);
         assert(s.events);
-        assert.equal(s.events.filter(e => e.request).length, 1);
-        assert.equal(s.events.filter(e => e.response).length, 1);
-        assert.equal(s.events.length, 2);
+        assert.equal(s.events.filter(e => e.type === 'connect').length, 1);
+        assert.equal(s.events.filter(e => e.type === 'request').length, 1);
+        assert.equal(s.events.filter(e => e.type === 'response').length, 1);
+        assert.equal(s.events.length, 3);
         assert(s.connection);
         assert.equal(s.connection.port, port);
         assert.equal(s.connection.host, '127.0.0.1');
@@ -62,9 +63,9 @@ test('tracks only what is created inside tracking loop', () => {
       if (err) return reject(err);
       const s = log[0];
       assert.equal(log.length, 1);
-      assert.equal(s.events.filter(e => e.request).length, 1);
+      assert.equal(s.events.filter(e => e.type === 'request').length, 1);
       assert.equal(s.events.length, 1);
-      assert(s.events[0].request.indexOf('World') !== -1);
+      assert(s.events[0].data.indexOf('World') !== -1);
       assert.equal(s.source, 'stdout');
       resolve();
     });
@@ -135,11 +136,13 @@ test('tracks https socket requests and responses', async () => {
         }, (res, log) => {
           const s = log[0];
           assert(s.events);
-          assert.equal(s.events.length, 2);
-          assert.equal(s.events.filter(e => e.request).length, 1);
-          const responses = s.events.filter(e => e.response);
+          assert.equal(s.events.length, 5);
+          assert.equal(s.events.filter(e => e.type === 'request').length, 1);
+          assert.equal(s.events.filter(e => e.type === 'connect').length, 1);
+          assert.equal(s.events.filter(e => e.type === 'secureConnect').length, 1);
+          const responses = s.events.filter(e => e.type === 'response');
           assert.equal(responses.length, 1);
-          assert(responses[0].response.indexOf('200 OK') !== -1);
+          assert(responses[0].data.indexOf('200 OK') !== -1);
           assert.equal(s.source, 'tcp');
           server.close(resolve);
         });
@@ -169,7 +172,7 @@ test('tracks console.log', async () => {
   const s = log[0];
   assert(s.events);
   assert.equal(s.events.length, 1);
-  assert(s.events[0].request);
+  assert(s.events[0].type === 'request');
   assert.equal(s.source, 'stdout');
 });
 
@@ -181,7 +184,7 @@ test('tracks console.error', async () => {
   const s = log[0];
   assert(s.events);
   assert.equal(s.events.length, 1);
-  assert(s.events[0].request);
+  assert(s.events[0].type === 'request');
   assert.equal(s.source, 'stderr');
 });
 
@@ -204,7 +207,7 @@ test('does not track after exiting track', async () => {
   const s = log[0];
   assert(s.events);
   assert.equal(s.events.length, 1);
-  assert(s.events[0].request);
+  assert(s.events[0].type === 'request');
   assert.equal(s.source, 'stdout');
 });
 
@@ -216,7 +219,7 @@ test('tracks child processes', async () => {
   const s = log[0];
   assert(s.events);
   assert.equal(s.events.length, 1);
-  assert(s.events[0].response);
+  assert(s.events[0].type === 'response');
   assert.equal(s.source, 'pipe');
 });
 
@@ -257,7 +260,7 @@ test('handles using async await syntax', async () => {
   const s = log[0];
   assert(s.events);
   assert.equal(s.events.length, 1);
-  assert(s.events[0].request);
+  assert(s.events[0].type === 'request');
   assert.equal(s.source, 'stdout');
 });
 


### PR DESCRIPTION
This changes how events are logged, using a `type` property. It also fixes an issue in tracking connections.  It properly separates connection information, especially important for FTP transactions.

Here's an example of an HTTPS request:

```
[
  { type: 'connect', created_at: 1651333440048.992 },
  {
    type: 'write',
    created_at: 1651333440049.308,
    data: 'GET / HTTP/1.1\r\nHost: 127.0.0.1:56927\r\nConnection: close\r\n\r\n'
  },
  { type: 'secure', created_at: 1651333440051.8499 },
  { type: 'secureConnect', created_at: 1651333440051.9941 },
  {
    type: 'read',
    created_at: 1651333440053.2744,
    data: 'HTTP/1.1 200 OK\r\n' +
      'X-Powered-By: Express\r\n' +
      'Content-length: 13\r\n' +
      'Date: Sat, 30 Apr 2022 15:44:00 GMT\r\n' +
      'Connection: close\r\n' +
      '\r\n' +
      'Hello, world!'
  }
]
```